### PR TITLE
Add function to callbackify variadic functions by guessing callback position

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,28 @@ getUserById.call({foo:true}, 12)
 // the underlying promise-returning function is called with the supplied context argument
 ```
 
-Note, `callbackify` only works on fixed-parameter length functions, not variadic functions. It determines whether or not you're passing in a continuation callback by counting parameters. If you can think of a more clever way, please send a PR!
+Normally, callbackify will only work with fixed-argument functions, and will use the declared
+parameter length to determine if the extra callback argument is present.  If you need to use
+callbackify with variadic functions, or functions that don't declare their full argument
+list, you can use:
+```js
+// options argument is optional
+var getUserById = callbackify.variadic(function (id, options) {
+  if (options === undefined) { options = {} }
+  if (options.select) {
+    return db.users.byId(id).select(options.select).first()
+  } else {
+    return db.users.byId(id).first()
+  }
+})
+
+// we can do either of these
+getUserById(23, function (err, user) { })
+getUserById(23, { select: [ 'name' ] }, function (err, user) {} )
+```
+Note that this will not work if the last argument your function can take
+is a function, as that last argument will always be detected as a callback
+function.
 
 ## api
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ getUserById.call({foo:true}, 12)
 // the underlying promise-returning function is called with the supplied context argument
 ```
 
-Normally, callbackify will only work with fixed-argument functions, and will use the declared
+Normally, callbackify will only work with fixed-parameter-length functions, and will use the declared
 parameter length to determine if the extra callback argument is present.  If you need to use
 callbackify with variadic functions, or functions that don't declare their full argument
 list, you can use:

--- a/index.js
+++ b/index.js
@@ -17,4 +17,23 @@ function callbackify(fn) {
   }
 }
 
+function callbackifyVariadic(fn) {
+  return function () {
+    var args = [].slice.call(arguments)
+    var ctx = this
+    if (args.length >= 1 &&
+        typeof args[args.length - 1] === 'function') {
+      // callback mode
+      var cb = args.pop()
+      fn.apply(this, args)
+        .then(function (val) { cb.call(ctx, null, val) },
+          function (err) { cb.call(ctx, err) })
+        return
+    }
+    // promise mode
+    return fn.apply(ctx, arguments)
+  }
+}
+
 module.exports = callbackify
+module.exports.variadic = callbackifyVariadic;

--- a/test/test.js
+++ b/test/test.js
@@ -80,4 +80,16 @@ describe('callbackify', function () {
 
   })
 
+  it('detects the callback with variadic functions', function (done) {
+    var foo = callbackify.variadic(function () {
+      return Promise.resolve(arguments[0])
+    })
+
+    foo(44, function (err, val) {
+      val.should.equal(44)
+      done()
+    })
+
+  })
+
 })


### PR DESCRIPTION
This change allows for most variadic functions to be used and is backwards-compatible with existing users of callbackify.
